### PR TITLE
fix: changed app id

### DIFF
--- a/packages/noodl-editor/package.json
+++ b/packages/noodl-editor/package.json
@@ -15,7 +15,7 @@
     "test:ci": "webpack-cli --config=webpackconfigs/webpack.test-ci.js && electron test.js"
   },
   "build": {
-    "appId": "noodl.net.noodl",
+    "appId": "noodl.net.noodl-editor",
     "protocols": {
       "name": "noodl",
       "schemes": [


### PR DESCRIPTION
 enables the old closed-source Noodl to be installed at the same time on Windows, and changes the install location