### PR TITLE
Bug fixes 5th Feb 2024 - state node and text node

### DIFF
--- a/packages/noodl-viewer-react/src/nodes/std-library/states.js
+++ b/packages/noodl-viewer-react/src/nodes/std-library/states.js
@@ -327,7 +327,15 @@ const StatesNode = {
       for (var i in internal.values) {
         var v = internal.values[i];
 
-        internal.currentValues[v] = internal.stateParameters[prefix + v] || 0;
+        // The below code was updated to stop the empty string value outputting as 0
+        // internal.currentValues[v] = internal.stateParameters[prefix + v] || 0;
+        const valueType = internal.stateParameterTypes['type-' + v] || 'number'; // New code to check if the type is defined, defaults to number
+        const parameterValue = internal.stateParameters[prefix + v];
+        if (valueType === 'string') {
+            internal.currentValues[v] = parameterValue !== undefined ? parameterValue : ""; // Outputs "" if value is set to string, otherwise outputs 0
+        } else {
+            internal.currentValues[v] = parameterValue !== undefined ? parameterValue : 0;
+        }
 
         this.flagOutputDirty(v);
       }

--- a/packages/noodl-viewer-react/src/nodes/visual/text.js
+++ b/packages/noodl-viewer-react/src/nodes/visual/text.js
@@ -140,7 +140,7 @@ const TextNode = {
 };
 
 NodeSharedPortDefinitions.addDimensions(TextNode, {
-  defaultSizeMode: 'contentHeight',
+  //defaultSizeMode: 'contentHeight', This causes a bug with initial content width taking up entire parent width irrespective of other responsive elements in the parent
   contentLabel: 'Text'
 });
 NodeSharedPortDefinitions.addTextStyleInputs(TextNode);


### PR DESCRIPTION
State node tested and now outputs "" empty string when state value is set to string type. Text node now also respects responsive width in relation to sibling nodes when initially placed. 