### PR TITLE
Update - 'duplicate' functionality

### DIFF
--- a/packages/noodl-editor/src/editor/src/views/documents/EditorDocument/EditorDocument.tsx
+++ b/packages/noodl-editor/src/editor/src/views/documents/EditorDocument/EditorDocument.tsx
@@ -517,6 +517,11 @@ function createKeyboardCommands(nodeGraph: NodeGraphEditor) {
     keybinding: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_Z
   };
 
+  const duplicate: KeyboardCommand = {
+    handler: () => nodeGraph.duplicate(),
+    keybinding: KeyMod.CtrlCmd | KeyCode.KEY_D
+  };
+
   const navBack: KeyboardCommand = {
     handler: () => nodeGraph.navigationHistory.goBack(),
     keybinding: KeyMod.CtrlCmd | KeyCode.US_OPEN_SQUARE_BRACKET
@@ -553,7 +558,7 @@ function createKeyboardCommands(nodeGraph: NodeGraphEditor) {
     keybinding: KeyMod.CtrlCmd | KeyCode.US_SLASH
   };
 
-  return [copy, paste, cut, undo, redo, navBack, navForward, deleteWithBackspace, deleteWithDel, createComment];
+  return [copy, paste, cut, undo, redo, duplicate, navBack, navForward, deleteWithBackspace, deleteWithDel, createComment];
 }
 
 export class EditorDocumentProvider implements IDocumentProvider {

--- a/packages/noodl-editor/src/editor/src/views/nodegrapheditor.ts
+++ b/packages/noodl-editor/src/editor/src/views/nodegrapheditor.ts
@@ -894,9 +894,7 @@ export class NodeGraphEditor extends View {
     } else {
       this.clipboard = undefined;
     }
-
-    ToastLayer.showInteraction('Copied');
-
+    
     return nodeset;
   }
 
@@ -930,6 +928,7 @@ export class NodeGraphEditor extends View {
 
   copy() {
     this.copySelected();
+    ToastLayer.showInteraction('Copied');
   }
 
   cut() {
@@ -1095,6 +1094,25 @@ export class NodeGraphEditor extends View {
     }
   }
 
+  duplicate() {
+    if (this.readOnly) {
+      return false;
+    }
+
+    const nodeset = this.copySelected();
+    if (nodeset === undefined) return;
+
+    const ns = this.getNodeSetFromClipboard() || this.clipboard;
+    if (!ns) return;
+
+    this.insertNodeSet({
+      nodeset: ns,
+      x: this.latestMousePos.x,
+      y: this.latestMousePos.y,
+      toastMessage: 'Duplicate'
+    });
+  }
+  
   getDevicePixelRatio(ctx) {
     const dpr = window.devicePixelRatio || 1;
     const bsr =

--- a/packages/noodl-editor/src/editor/src/views/nodegrapheditor.ts
+++ b/packages/noodl-editor/src/editor/src/views/nodegrapheditor.ts
@@ -1109,7 +1109,7 @@ export class NodeGraphEditor extends View {
       nodeset: ns,
       x: this.latestMousePos.x,
       y: this.latestMousePos.y,
-      toastMessage: 'Duplicate'
+      toastMessage: 'Duplicated'
     });
   }
   


### PR DESCRIPTION
A quick way to copy-paste selected elements for those coming from Figma and similar tools where such functionality exists. 

I have a feeling that there's more to creating this pull request (adding something to tests?) but in my build it seems to work nicely :) 

I've also moved the 'Copied' toast from the copySelected() into copy() as it was also showing up while using cut() - 2 toasts (Copied and Cut). I understand that under the hood it copies selection into the clipboard, but visualising that with a toast event when cutting or duplicating is not necessary, as only the end-result is important for the user. 